### PR TITLE
Remove pthreads and use native PHP calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 nbproject
 composer.lock
 docker-compose.yml
+logs/*.log

--- a/README.md
+++ b/README.md
@@ -35,16 +35,16 @@ Install dependencies with:
 $ docker run --rm -i -v $(pwd):/app prooph/composer:7.1 update -o
 ```
 
-Then you can simply run the `bench.sh` script for each driver (`arangodb` `postgres` `mysql` `mariadb`):
+Then you can simply run the `bench_docker.sh` script for each driver (`arangodb` `postgres` `mysql` `mariadb`):
 
 ```
-$ . bench.sh --driver postgres
+$ . bench_docker.sh --driver postgres
 ```
 
 Or to run all benchmarks
 
 ```
-$ . bench_all.sh > results.log
+$ . bench_docker_all.sh > results.log
 ```
 
 ### Manual
@@ -52,7 +52,7 @@ $ . bench_all.sh > results.log
 1) Have MySQL, MariaDB, Postgres, ArangoDB installed and running
 2) Edit `.env` file and change your db settings
 3) Create the test database according to your settings
-4) run `php src/benchmark.php` or `DRIVER=postgres php src/benchmark.php`
+4) run `. bench.sh --driver postgres` or `. bench_all.sh > results.log`
 5) enjoy
 
 ## Good to know
@@ -64,12 +64,6 @@ This is the most realistic test case that comes close to production usage:
 - 6 projections are reading events at the same time
 - a total of 12500 events are written
 - a total of 25000 events are read
-
-You need to have PHP 7.2 and pthreads extension installed for test7 (real world test).
-
-There is currently a bug in pthreads (https://github.com/krakjoe/pthreads/issues/760)
-and a suggested fix, but for now during benchmark the `\Prooph\EventStore\Pdo\Projection\PdoEventStoreProjector`
-is patched in order to work with pthreads.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ . bench_docker_all.sh > results.log
 1) Have MySQL, MariaDB, Postgres, ArangoDB installed and running
 2) Edit `.env` file and change your db settings
 3) Create the test database according to your settings
-4) run `. bench.sh --driver postgres` or `. bench_all.sh > results.log`
+4) run `. bench.sh --driver postgres` or `. bench_all.sh > results.log` or `. bench.sh --driver postgres,arangodb`
 5) enjoy
 
 ## Good to know

--- a/bench.sh
+++ b/bench.sh
@@ -26,6 +26,8 @@ if [ -z "${DRIVER}" ]; then
     return 1
 fi
 
+export DRIVER=${DRIVER}
+
 echo ""
 echo "Starting benchmark ${DRIVER}!"
 php src/prepare.php

--- a/bench_all.sh
+++ b/bench_all.sh
@@ -1,23 +1,17 @@
-#!/bin/bash -ex
-
-GREEN=`tput setaf 2`
-RESET=`tput sgr0`
-
-declare -a arr=("arangodb" "postgres" "mariadb" "mysql")
-arr=( $(shuf -e "${arr[@]}") )
+#!/usr/bin/env sh
 
 echo ""
-printf "${GREEN}Testing databases are ${RESET}"
-for i in "${arr[@]}"
+printf "Testing databases are "
+
+for i in arangodb postgres mariadb mysql
 do
-   printf  ${i}
-   printf " "
+   printf  "%s " "${i}"
 done
 
 echo ""
 sleep 2;
 
-for i in "${arr[@]}"
+for i in arangodb postgres mariadb mysql
 do
-   bash bench.sh --driver ${i}
+   ./bench.sh --driver ${i}
 done

--- a/bench_docker.sh
+++ b/bench_docker.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env sh
+
+USAGE="Usage: bench_docker.sh --driver [arangodb | postgres | mysql | mariadb]"
+
+IDLE_TIME=20
+DRIVER=
+
+while [ "${1}" ]; do
+    case "${1}" in
+        --driver)
+            DRIVER=${2}
+            shift
+            ;;
+        *)
+            echo "${USAGE}" >&2
+            return 1
+    esac
+
+    if ! shift; then
+        echo "Missing parameter argument. $USAGE" >&2
+        return 1
+    fi
+done
+
+if [ -z "${DRIVER}" ]; then
+    echo "${USAGE}" >&2
+    return 1
+fi
+
+CPU=$(($(grep -c ^processor /proc/cpuinfo) / 2))
+MEM=$( (grep -E 'MemAvailable' /proc/meminfo) | (rev) | (cut -d " " -f 2) | (rev) )
+MEM=$((MEM / 1024 - 1024))
+BUFFER_POOL_SIZE=$((MEM * 70 / 100))
+PHP_CPU=
+DB_CPU=
+
+COUNTER=0
+while [  $COUNTER -lt ${CPU} ]; do
+    if [ $COUNTER -ne 0 ]; then
+        PHP_CPU=${PHP_CPU}","
+        DB_CPU=${DB_CPU}","
+    fi
+
+    PHP_CPU=${PHP_CPU}$((COUNTER * 2))
+    DB_CPU=${DB_CPU}$((COUNTER * 2 + 1))
+    COUNTER=$((COUNTER + 1))
+done
+
+cp docker-compose-"${DRIVER}".yml docker-compose.yml
+sed -i "s/#cpuset: phpcpuset/cpuset: ${PHP_CPU}/g" docker-compose.yml
+sed -i "s/#cpu_count: phpcpu_count/cpu_count: ${CPU}/g" docker-compose.yml
+sed -i "s/#mem_limit: phpmem_limit/mem_limit: 768M/g" docker-compose.yml
+sed -i "s/#mem_reservation: phpmem_reservation/mem_reservation: 768M/g" docker-compose.yml
+
+sed -i "s/#cpuset: dbcpuset/cpuset: ${DB_CPU}/g" docker-compose.yml
+sed -i "s/#cpu_count: dbcpu_count/cpu_count: ${CPU}/g" docker-compose.yml
+sed -i "s/#mem_limit: dbmem_limit/mem_limit: ${MEM}M/g" docker-compose.yml
+sed -i "s/#mem_reservation: dbmem_reservation/mem_reservation: ${MEM}M/g" docker-compose.yml
+
+sed -i "s/BUFFER_POOL_SIZE/${BUFFER_POOL_SIZE}M/g" docker-compose.yml
+
+docker-compose up -d --no-recreate database
+docker-compose ps
+
+echo ""
+echo ""
+echo "Docker Info"
+docker info
+
+echo ""
+echo ""
+echo "Hardware Info"
+lscpu
+
+echo ""
+echo ""
+echo "Using ${CPU} CPUs for each service and ${MEM} MB memory for database."
+
+echo "Waiting for ${DRIVER} database, lean back to enjoy the timer."
+until [ $IDLE_TIME -lt 1 ]; do
+
+    IDLE_TIME=$((IDLE_TIME - 1))
+    printf "%s " "${IDLE_TIME}"
+    sleep 1
+done
+docker-compose run --rm --entrypoint=sh php ./bench.sh --driver "${DRIVER}"
+
+echo ""
+echo "Dumping logs ${DRIVER}!"
+docker-compose logs
+
+docker-compose down -v

--- a/bench_docker_all.sh
+++ b/bench_docker_all.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -ex
+
+GREEN=`tput setaf 2`
+RESET=`tput sgr0`
+
+declare -a arr=("arangodb" "postgres" "mariadb" "mysql")
+arr=( $(shuf -e "${arr[@]}") )
+
+echo ""
+printf "${GREEN}Testing databases are ${RESET}"
+for i in "${arr[@]}"
+do
+   printf  ${i}
+   printf " "
+done
+
+echo ""
+sleep 2;
+
+for i in "${arr[@]}"
+do
+   bash bench_docker.sh --driver ${i}
+done

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,12 @@
 {
   "name": "prooph/event-store-benchmarks",
   "license": "BSD-3-Clause",
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "require":{
     "prooph/pdo-event-store":"^1.5.1",
     "prooph/arangodb-event-store":"dev-master",
+    "prooph/arangodb-php-driver-polyfill":"dev-master",
     "psr/container":"^1.0",
     "zendframework/zend-servicemanager":"^3.3",
     "vlucas/phpdotenv": "^2.4"
@@ -31,6 +34,10 @@
     {
       "type": "git",
       "url": "https://github.com/sandrokeil/arangodb-event-store.git"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/sandrokeil/arangodb-php-driver-polyfill"
     }
   ]
 }

--- a/docker-compose-arangodb.yml
+++ b/docker-compose-arangodb.yml
@@ -2,11 +2,11 @@ version: '2.3'
 services:
   # To run benchmark suite docker-compose run --rm php src/benchmark
   php:
-    image: prooph/php:7.2-zts
+    image: prooph/php:7.2-cli
     environment:
       DRIVER: "arangodb"
       PHP_IDE_CONFIG: "serverName=application"
-      ARANGODB_HOST: "tcp://arangodb:8529"
+      ARANGODB_HOST: "tcp://database:8529"
       ARANGODB_USERNAME: ""
       ARANGODB_PASSWORD: ""
       ARANGODB_DB: _system
@@ -17,7 +17,7 @@ services:
     #mem_limit: phpmem_limit
     #mem_reservation: phpmem_reservation
 
-  arangodb:
+  database:
     image: arangodb:3.2
     ports:
       - 8529:8529

--- a/docker-compose-mariadb.yml
+++ b/docker-compose-mariadb.yml
@@ -2,12 +2,12 @@ version: '2.3'
 services:
   # To run benchmark suite docker-compose run --rm php src/benchmark
   php:
-    image: prooph/php:7.2-zts
+    image: prooph/php:7.2-cli
     environment:
       DRIVER: "mariadb"
       MARIADB_USER: "dev"
       MARIADB_PASSWORD: "dev"
-      MARIADB_HOST: "mariadb"
+      MARIADB_HOST: "database"
       MARIADB_PORT: "3306"
       MARIADB_CHARSET: "utf8"
       MARIADB_DB: "event_store_tests"
@@ -18,7 +18,7 @@ services:
     #mem_limit: phpmem_limit
     #mem_reservation: phpmem_reservation
 
-  mariadb:
+  database:
     image: mariadb:10.3
     ports:
       - 3306
@@ -27,6 +27,7 @@ services:
       MYSQL_DATABASE: "event_store_tests"
       MYSQL_USER: "dev"
       MYSQL_PASSWORD: "dev"
+    command: "--max_connections=2500 --innodb_buffer_pool_size=BUFFER_POOL_SIZE --query_cache_type=1 --query_cache_limit=256K --query_cache_min_res_unit=2k --query_cache_size=100M --tmp_table_size=64M --max_heap_table_size=64M --max_allowed_packet=256M"
     #cpuset: dbcpuset
     #cpu_count: dbcpu_count
     #mem_limit: dbmem_limit

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -2,12 +2,12 @@ version: '2.3'
 services:
   # To run benchmark suite docker-compose run --rm php src/benchmark
   php:
-    image: prooph/php:7.2-zts
+    image: prooph/php:7.2-cli
     environment:
       DRIVER: "mysql"
       MYSQL_USER: "dev"
       MYSQL_PASSWORD: "dev"
-      MYSQL_HOST: "mysql"
+      MYSQL_HOST: "database"
       MYSQL_PORT: "3306"
       MYSQL_CHARSET: "utf8"
       MYSQL_DB: "event_store_tests"
@@ -18,7 +18,7 @@ services:
     #mem_limit: phpmem_limit
     #mem_reservation: phpmem_reservation
 
-  mysql:
+  database:
     # mysql 8.0 not working properly
     # see https://github.com/docker-library/mysql/issues/303
     image: mysql:5.7
@@ -29,6 +29,7 @@ services:
       MYSQL_DATABASE: "event_store_tests"
       MYSQL_USER: "dev"
       MYSQL_PASSWORD: "dev"
+    command: "--max_connections=2500 --innodb_buffer_pool_size=BUFFER_POOL_SIZE --query_cache_type=1 --query_cache_limit=256K --query_cache_min_res_unit=2k --query_cache_size=100M --tmp_table_size=64M --max_heap_table_size=64M --max_allowed_packet=256M"
     #cpuset: dbcpuset
     #cpu_count: dbcpu_count
     #mem_limit: dbmem_limit

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -2,12 +2,12 @@ version: '2.3'
 services:
   # To run benchmark suite docker-compose run --rm php src/benchmark
   php:
-    image: prooph/php:7.2-zts
+    image: prooph/php:7.2-cli
     environment:
       DRIVER: "postgres"
       POSTGRES_USER: "dev"
       POSTGRES_PASSWORD: "dev"
-      POSTGRES_HOST: "postgres"
+      POSTGRES_HOST: "database"
       POSTGRES_PORT: "5432"
       POSTGRES_CHARSET: "utf8"
       POSTGRES_DB: "event_store_tests"
@@ -18,7 +18,7 @@ services:
     #mem_limit: phpmem_limit
     #mem_reservation: phpmem_reservation
 
-  postgres:
+  database:
     image: postgres:9.6
     ports:
       - 5432:5432
@@ -26,6 +26,7 @@ services:
       POSTGRES_DB: "event_store_tests"
       POSTGRES_USER: "dev"
       POSTGRES_PASSWORD: "dev"
+    command: "-c 'max_connections=200'"
     #cpuset: dbcpuset
     #cpu_count: dbcpu_count
     #mem_limit: dbmem_limit

--- a/src/AllProjector.php
+++ b/src/AllProjector.php
@@ -6,21 +6,22 @@ namespace Prooph\EventStoreBenchmarks;
 
 use Prooph\Common\Messaging\Message;
 
-class AllProjector extends \Thread
+class AllProjector
 {
+    private $id;
     private $driver;
     private $stopAt;
 
-    public function __construct(string $driver, int $stopAt)
+    public function __construct(string $id, string $driver, int $stopAt)
     {
+        $this->id = $id;
         $this->driver = $driver;
         $this->stopAt = $stopAt;
     }
 
     public function run()
     {
-        $id = $this->getThreadId();
-        echo "Projection $id started\n";
+        outputText("Projection $this->id started");
 
         try {
             $connection = createConnection($this->driver);
@@ -54,8 +55,8 @@ class AllProjector extends \Thread
             $time = $end - $start;
             $avg = $this->stopAt / $time;
 
-            echo "Projection $id read $readEvents events\n";
-            echo "projection $id used $time seconds, avg $avg events/second\n";
+            outputText("Projection $this->id read $readEvents events");
+            outputText("projection $this->id used $time seconds, avg $avg events/second");
         } catch (\Throwable $e) {
             echo $e->getMessage() . PHP_EOL . $e->getTraceAsString();
         }

--- a/src/CategoryProjector.php
+++ b/src/CategoryProjector.php
@@ -7,14 +7,16 @@ namespace Prooph\EventStoreBenchmarks;
 use Prooph\Common\Messaging\Message;
 use Ramsey\Uuid\Uuid;
 
-class CategoryProjector extends \Thread
+class CategoryProjector
 {
+    private $id;
     private $driver;
     private $category;
     private $stopAt;
 
-    public function __construct(string $driver, string $category, int $stopAt)
+    public function __construct(string $id, string $driver, string $category, int $stopAt)
     {
+        $this->id = $id;
         $this->driver = $driver;
         $this->category = $category;
         $this->stopAt = $stopAt;
@@ -22,8 +24,7 @@ class CategoryProjector extends \Thread
 
     public function run()
     {
-        $id = $this->getThreadId();
-        echo "Projection $id started\n";
+        outputText("Projection $this->id started");
 
         try {
             $connection = createConnection($this->driver);
@@ -58,8 +59,8 @@ class CategoryProjector extends \Thread
             $time = $end - $start;
             $avg = $this->stopAt / $time;
 
-            echo "Projection $id read $readEvents events\n";
-            echo "projection $id used $time seconds, avg $avg events/second\n";
+            outputText("Projection $this->id read $readEvents events");
+            outputText("projection $this->id used $time seconds, avg $avg events/second");
         } catch (\Throwable $e) {
             echo $e->getMessage() . PHP_EOL . $e->getTraceAsString();
         }

--- a/src/StreamCreator.php
+++ b/src/StreamCreator.php
@@ -9,16 +9,18 @@ use Prooph\EventStore\StreamName;
 use Prooph\EventStore\TransactionalEventStore;
 use Ramsey\Uuid\Uuid;
 
-class StreamCreator extends \Thread
+class StreamCreator
 {
+    private $id;
     private $eventsWritten;
     private $driver;
     private $category;
     private $executions;
     private $numberOfEvents;
 
-    public function __construct(string $driver, string $category, int $executions, int $numberOfEvents)
+    public function __construct(string $id, string $driver, string $category, int $executions, int $numberOfEvents)
     {
+        $this->id = $id;
         $this->eventsWritten = 0;
         $this->driver = $driver;
         $this->category = $category;
@@ -28,8 +30,7 @@ class StreamCreator extends \Thread
 
     public function run()
     {
-        $id = $this->getThreadId();
-        echo "Writer $id started\n";
+        outputText("Writer $this->id-$this->category started");
 
         try {
             $connection = createConnection($this->driver);
@@ -60,8 +61,8 @@ class StreamCreator extends \Thread
             $time = $end - $start;
             $avg = ($this->executions * $this->numberOfEvents) / $time;
 
-            echo "Writer $id wrote $this->eventsWritten events\n";
-            echo "Writer $id used $time seconds, avg $avg events/second\n";
+            outputText("Writer $this->id-$this->category wrote $this->eventsWritten events");
+            outputText("Writer $this->id-$this->category used $time seconds, avg $avg events/second");
         } catch (\Throwable $e) {
             echo $e->getMessage() . PHP_EOL . $e->getTraceAsString();
         }

--- a/src/benchmark.php
+++ b/src/benchmark.php
@@ -7,8 +7,6 @@ namespace Prooph\EventStoreBenchmarks;
 use Dotenv\Dotenv;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
-use Prooph\EventStore\Exception\StreamNotFound;
-use Prooph\EventStore\Pdo\Exception\RuntimeException;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
@@ -17,66 +15,21 @@ use Ramsey\Uuid\Uuid;
 
 chdir(__DIR__);
 
-$autoloader = require '../vendor/autoload.php';
+require '../vendor/autoload.php';
 require 'functions.php';
-
-$realWorldTest = true;
-
-if (version_compare(PHP_VERSION, '7.2.0beta') < 0) {
-    echo 'Your PHP Version is ' . PHP_VERSION . ', so "real-world-test" is skipped' . "\n\n";
-    $realWorldTest = false;
-}
-
-if (! extension_loaded('pthreads')) {
-    echo 'You don\'t have pthreads installed, so "real-world-test" is skipped' . "\n\n";
-    $realWorldTest = false;
-}
-
-// patching pdo-event-store projector (see: https://github.com/krakjoe/pthreads/issues/760)
-if ($realWorldTest) {
-    $filename = '../vendor/prooph/pdo-event-store/src/Projection/PdoEventStoreProjector.php';
-    $content = file_get_contents($filename);
-    $newContent = str_replace('private const', 'const', $content);
-    file_put_contents($filename, $newContent);
-
-    $filenameConnectionOptions = '../vendor/triagens/arangodb/lib/ArangoDBClient/ConnectionOptions.php';
-    $contentConnectionOptions = file_get_contents($filenameConnectionOptions);
-    $newContentConnectionOptions = str_replace('DefaultValues::DEFAULT_CIPHERS', 'null', $contentConnectionOptions);
-    file_put_contents($filenameConnectionOptions, $newContentConnectionOptions);
-
-    $filenameArangoDbEventStore = '../vendor/prooph/arangodb-event-store/src/EventStore.php';
-    $contentArangoDbEventStore = file_get_contents($filenameArangoDbEventStore);
-    $newContentArangoDbEventStore = str_replace('private const', 'const', $contentArangoDbEventStore);
-    file_put_contents($filenameArangoDbEventStore, $newContentArangoDbEventStore);
-}
 
 $dotenv = new Dotenv('..');
 $dotenv->load();
 
 $connections = createConnections();
-$dbNames = testDatabases();
 $payload = testPayload();
-
-register_shutdown_function(function () use ($connections, $dbNames) {
-    foreach ($connections as $name => $connection) {
-        echo "$name: destroying event-store tables on database $dbNames[$name]\n";
-        destroyDatabase($connection, $name,  $dbNames[$name]);
-    }
-});
-
-foreach ($connections as $name => $connection) {
-    echo "$name: set up event store tables on database $dbNames[$name]\n";
-    createDatabase($connection, $name,  $dbNames[$name]);
-}
-
-echo "\n";
 
 $eventStores = createEventStores($connections);
 $projectionManagers = createProjectionManagers($eventStores, $connections);
 
 // test 1 - create 10 streams with 100 events in each stream, using 1 event per commit
 
-echo "test 1 create 10 streams with 100 events in each stream, using 1 event per commit\n\n";
+outputText("test 1 create 10 streams with 100 events in each stream, using 1 event per commit\n");
 
 foreach ($eventStores as $name => $eventStore) {
     /* @var EventStore $eventStore */
@@ -101,13 +54,13 @@ foreach ($eventStores as $name => $eventStore) {
     $time = $end - $start;
     $eventsPerSecond = 1000 / $time;
 
-    echo "test 1 using $name took $time seconds\n";
-    echo "test 1 using $name writes $eventsPerSecond events per second\n\n";
+    outputText("test 1 using $name took $time seconds");
+    outputText("test 1 using $name writes $eventsPerSecond events per second\n");
 }
 
 // test 2 - create 10 streams with 100 events in each stream, using 5 events per commit
 
-echo "test 2 create 10 streams with 100 events in each stream, using 5 events per commit\n\n";
+outputText("test 2 create 10 streams with 100 events in each stream, using 5 events per commit\n");
 
 foreach ($eventStores as $name => $eventStore) {
     /* @var EventStore $eventStore */
@@ -134,13 +87,13 @@ foreach ($eventStores as $name => $eventStore) {
     $time = $end - $start;
     $eventsPerSecond = 1000 / $time;
 
-    echo "test 2 using $name took $time seconds\n";
-    echo "test 2 using $name writes $eventsPerSecond events per second\n\n";
+    outputText("test 2 using $name took $time seconds");
+    outputText("test 2 using $name writes $eventsPerSecond events per second\n");
 }
 
 // test 3 - create one stream with 2500 events using a single commit
 
-echo "test 3 create one stream with 2500 events using a single commit\n\n";
+outputText("test 3 create one stream with 2500 events using a single commit\n");
 
 foreach ($eventStores as $name => $eventStore) {
     /* @var EventStore $eventStore */
@@ -161,8 +114,8 @@ foreach ($eventStores as $name => $eventStore) {
     $time = $end - $start;
     $eventsPerSecond = 2500 / $time;
 
-    echo "test 3 using $name took $time seconds\n";
-    echo "test 3 using $name writes $eventsPerSecond events per second\n\n";
+    outputText("test 3 using $name took $time seconds");
+    outputText("test 3 using $name writes $eventsPerSecond events per second\n");
 
     $streamNamesTest3[$name] = $streamName;
 }
@@ -170,7 +123,7 @@ foreach ($eventStores as $name => $eventStore) {
 // test 4 - load one stream with 2500 events
 // $streamNames are reused from test 3
 
-echo "test 4 load one stream with 2500 events\n\n";
+outputText("test 4 load one stream with 2500 events\n");
 
 foreach ($eventStores as $name => $eventStore) {
     /* @var EventStore $eventStore */
@@ -180,18 +133,18 @@ foreach ($eventStores as $name => $eventStore) {
     $time = $end - $start;
     $eventsPerSecond = 2500 / $time;
 
-    echo "test 4 using $name took $time seconds\n";
-    echo "test 4 using $name loads $eventsPerSecond events per second\n\n";
+    outputText("test 4 using $name took $time seconds");
+    outputText("test 4 using $name loads $eventsPerSecond events per second\n");
 }
 
 // test 5 - project 1 stream with 2500 events
 // $streamNames are reused from test 3
 
-echo "test 5 project 1 stream with 2500 events\n\n";
+outputText("test 5 project 1 stream with 2500 events\n");
 
 foreach ($projectionManagers as $name => $projectionManager) {
     /* @var ProjectionManager $projectionManager */
-    $projection = $projectionManager->createProjection('test_projection');
+    $projection = $projectionManager->createProjection('test_projection_5');
     $projection
         ->init(function (): array {
             return ['count' => 0];
@@ -208,14 +161,14 @@ foreach ($projectionManagers as $name => $projectionManager) {
     $time = $end - $start;
     $eventsPerSecond = 2500 / $time;
 
-    echo "test 5 using $name took $time seconds\n";
-    echo "test 5 using $name loads $eventsPerSecond events per second\n\n";
+    outputText("test 5 using $name took $time seconds");
+    outputText("test 5 using $name loads $eventsPerSecond events per second\n");
 }
 
 // test 6 - project 10 streams with 100 events each
 // $streamNames are reused from test 1
 
-echo "test 6 project 10 stream with 100 events\n\n";
+outputText("test 6 project 10 stream with 100 events\n");
 
 foreach ($projectionManagers as $name => $projectionManager) {
     /* @var ProjectionManager $projectionManager */
@@ -223,7 +176,7 @@ foreach ($projectionManagers as $name => $projectionManager) {
     foreach ($streamNamesTest1[$name] as $streamName) {
         $streamNames[] = $streamName->toString();
     }
-    $projection = $projectionManager->createProjection('test_projection');
+    $projection = $projectionManager->createProjection('test_projection_6');
     $projection
         ->init(function (): array {
             return ['count' => 0];
@@ -240,85 +193,6 @@ foreach ($projectionManagers as $name => $projectionManager) {
     $time = $end - $start;
     $eventsPerSecond = 1000 / $time;
 
-    echo "test 6 using $name took $time seconds\n";
-    echo "test 6 using $name loads $eventsPerSecond events per second\n\n";
+    outputText("test 6 using $name took $time seconds");
+    outputText("test 6 using $name loads $eventsPerSecond events per second\n");
 }
-
-if (! $realWorldTest) {
-    echo "real-world-test skipped\n\n";
-    exit(0);
-}
-
-// test 7 - real world test
-
-test7:
-
-echo "test 7 real world test\n\n";
-
-// loading classes for pthreads
-$autoloader->loadClass(StreamNotFound::class);
-$autoloader->loadClass(RuntimeException::class);
-
-foreach ($connections as $name => $connection) {
-    echo "$name: destroying event-store tables on database $dbNames[$name]\n";
-    destroyDatabase($connection, $name,  $dbNames[$name]);
-    echo "$name: set up event store tables on database $dbNames[$name]\n";
-    createDatabase($connection, $name,  $dbNames[$name]);
-}
-
-echo "\n";
-
-foreach ($connections as $driver => $connection) {
-    echo "starting benchmarks for $driver\n\n";
-
-    $writers = [];
-    $projectors = [];
-
-    for ($i = 0; $i < 10; $i++) {
-        $writers[] = new StreamCreator($driver, 'user', 50, 5);
-        $writers[] = new StreamCreator($driver, 'post', 50, 5);
-        $writers[] = new StreamCreator($driver, 'todo', 50, 5);
-        $writers[] = new StreamCreator($driver, 'blog', 50, 5);
-        $writers[] = new StreamCreator($driver, 'comment', 50, 5);
-    }
-
-    $projectors[] = new CategoryProjector($driver, 'user', 2500);
-    $projectors[] = new CategoryProjector($driver, 'post', 2500);
-    $projectors[] = new CategoryProjector($driver, 'todo', 2500);
-    $projectors[] = new CategoryProjector($driver, 'blog', 2500);
-    $projectors[] = new CategoryProjector($driver, 'comment', 2500);
-    $projectors[] = new AllProjector($driver, 12500);
-
-    $startWriters = microtime(true);
-    foreach ($writers as $writer) {
-        $writer->start();
-    }
-
-    $startProjectors = microtime(true);
-    foreach ($projectors as $projector) {
-        $projector->start();
-    }
-
-    foreach ($writers as $writer) {
-        $writer->join();
-    }
-    $endWriters = microtime(true);
-
-    foreach ($projectors as $projector) {
-        $projector->join();
-    }
-    $endProjectors = microtime(true);
-
-    echo "\ndone.\n";
-    $avgWriters = 12500 / ($endWriters - $startWriters);
-    $avgReaders = 25000 / ($endProjectors - $startProjectors);
-    echo "$driver avg writes $avgWriters events/second\n";
-    echo "$driver avg reads $avgReaders events/second\n\n";
-}
-
-// revert patching of pdo-event-store projector
-file_put_contents($filename, $content);
-file_put_contents($filenameArangoDbEventStore, $contentArangoDbEventStore);
-file_put_contents($filenameConnectionOptions, $contentConnectionOptions);
-
-echo "all finished\n";

--- a/src/benchmark.php
+++ b/src/benchmark.php
@@ -21,7 +21,11 @@ require 'functions.php';
 $dotenv = new Dotenv('..');
 $dotenv->load();
 
-$connections = createConnections();
+if (false === ($drivers = getenv('DRIVER'))) {
+    throw new \RuntimeException('No DRIVER environment variable set.');
+}
+
+$connections = createConnections(explode(',', $drivers));
 $payload = testPayload();
 
 $eventStores = createEventStores($connections);

--- a/src/cleanup.php
+++ b/src/cleanup.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prooph\EventStoreBenchmarks;
+
+use Dotenv\Dotenv;
+
+chdir(__DIR__);
+
+require '../vendor/autoload.php';
+require 'functions.php';
+
+$dotenv = new Dotenv('..');
+$dotenv->load();
+
+$connections = createConnections();
+$dbNames = testDatabases();
+
+foreach ($connections as $name => $connection) {
+    outputText("$name: destroying event-store tables on database $dbNames[$name]");
+    destroyDatabase($connection, $name,  $dbNames[$name]);
+}

--- a/src/cleanup.php
+++ b/src/cleanup.php
@@ -14,7 +14,11 @@ require 'functions.php';
 $dotenv = new Dotenv('..');
 $dotenv->load();
 
-$connections = createConnections();
+if (false === ($drivers = getenv('DRIVER'))) {
+    throw new \RuntimeException('No DRIVER environment variable set.');
+}
+
+$connections = createConnections(explode(',', $drivers));
 $dbNames = testDatabases();
 
 foreach ($connections as $name => $connection) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -308,3 +308,9 @@ function testPayload(): array
         'key7' => 7,
     ];
 }
+
+
+function outputText(string $text) {
+    $time = new \DateTime('now');
+    echo $time->format('Y-m-d\TH:i:s.u') . ': ' . $text . PHP_EOL;
+}

--- a/src/prepare.php
+++ b/src/prepare.php
@@ -14,7 +14,11 @@ require 'functions.php';
 $dotenv = new Dotenv('..');
 $dotenv->load();
 
-$connections = createConnections();
+if (false === ($drivers = getenv('DRIVER'))) {
+    throw new \RuntimeException('No DRIVER environment variable set.');
+}
+
+$connections = createConnections(explode(',', $drivers));
 $dbNames = testDatabases();
 
 foreach ($connections as $name => $connection) {

--- a/src/prepare.php
+++ b/src/prepare.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prooph\EventStoreBenchmarks;
+
+use Dotenv\Dotenv;
+
+chdir(__DIR__);
+
+require '../vendor/autoload.php';
+require 'functions.php';
+
+$dotenv = new Dotenv('..');
+$dotenv->load();
+
+$connections = createConnections();
+$dbNames = testDatabases();
+
+foreach ($connections as $name => $connection) {
+    outputText("$name: set up event store tables on database $dbNames[$name]");
+    createDatabase($connection, $name,  $dbNames[$name]);
+}
+
+echo "\n";

--- a/src/projector.php
+++ b/src/projector.php
@@ -14,7 +14,11 @@ require 'functions.php';
 $dotenv = new Dotenv('..');
 $dotenv->load();
 
-$connections = createConnections();
+if (false === ($drivers = getenv('DRIVER'))) {
+    throw new \RuntimeException('No DRIVER environment variable set.');
+}
+
+$connections = createConnections(explode(',', $drivers));
 $name = $argv[1];
 $type = $argv[2];
 

--- a/src/projector.php
+++ b/src/projector.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prooph\EventStoreBenchmarks;
+
+use Dotenv\Dotenv;
+
+chdir(__DIR__);
+
+require '../vendor/autoload.php';
+require 'functions.php';
+
+$dotenv = new Dotenv('..');
+$dotenv->load();
+
+$connections = createConnections();
+$name = $argv[1];
+$type = $argv[2];
+
+foreach ($connections as $driver => $connection) {
+    if ($type === 'all') {
+        $projector = new AllProjector($name, $driver, 2500);
+        $projector->run();
+    } else {
+        $projector = new CategoryProjector($name, $driver, $type, 2500);
+        $projector->run();
+    }
+}

--- a/src/writer.php
+++ b/src/writer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prooph\EventStoreBenchmarks;
+
+use Dotenv\Dotenv;
+
+chdir(__DIR__);
+
+require '../vendor/autoload.php';
+require 'functions.php';
+
+
+$dotenv = new Dotenv('..');
+$dotenv->load();
+
+$connections = createConnections();
+$name = $argv[1];
+$type = $argv[2];
+
+foreach ($connections as $driver => $connection) {
+    $writer = new StreamCreator($name, $driver, $type, 50, 5);
+    $writer->run();
+}

--- a/src/writer.php
+++ b/src/writer.php
@@ -15,7 +15,11 @@ require 'functions.php';
 $dotenv = new Dotenv('..');
 $dotenv->load();
 
-$connections = createConnections();
+if (false === ($drivers = getenv('DRIVER'))) {
+    throw new \RuntimeException('No DRIVER environment variable set.');
+}
+
+$connections = createConnections(explode(',', $drivers));
 $name = $argv[1];
 $type = $argv[2];
 


### PR DESCRIPTION
This removes pthreads so we can use different PHP versions / event store real world tests. /cc @codeliner @martin-schilling

What do you think?